### PR TITLE
TORY-196 [AI Voice Command] 도커 배포 시 timeout으로 인해 CI 작업이 실패하는 문제 해결

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -74,6 +74,7 @@ jobs:
 
       - name: SSH to EC2 and deploy
         uses: appleboy/ssh-action@v1
+        timeout-minutes: 30
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}


### PR DESCRIPTION
chore: develop.yml에서 SSH action timeout을 30분으로 증가