### PR TITLE
Release v1.0.3

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -1,11 +1,14 @@
 from abc import ABC, abstractmethod
+from uuid import UUID
+
 import httpx
 from uvicorn.main import logger
-from src.intent.models import Intent
+
+from src.context import country_code_ctx
 from src.enums import STTProvider
+from src.intent.models import Intent
 from src.schemas import VoiceCommandRequest
 from .config import voice_command_config
-from uuid import UUID
 
 class VoiceCommandClient(ABC):
     @abstractmethod
@@ -19,8 +22,11 @@ class CheftoryVoiceCommandClient(VoiceCommandClient):
 
     async def send_result(self, stt_provider: STTProvider, result: Intent, user_id: UUID, session_id: str, start: int, end: int):
         url = f"{self.config.api_base}/papi/v1/voice-command"
+        headers = {
+            "X-Country-Code": country_code_ctx.get(),
+        }
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(headers=headers) as client:
                 await client.post(
                 url,
                 json=VoiceCommandRequest.from_intent(result, user_id, stt_provider, session_id, start, end).model_dump()

--- a/src/context.py
+++ b/src/context.py
@@ -1,0 +1,10 @@
+from contextvars import ContextVar
+
+
+def normalize_country_code(raw: str | None) -> str:
+    if raw and raw.upper() == "KR":
+        return "KR"
+    return "US"
+
+
+country_code_ctx: ContextVar[str] = ContextVar("country_code_ctx", default="US")

--- a/src/router.py
+++ b/src/router.py
@@ -7,6 +7,7 @@ from src.deps import voice_command_service
 from src.exceptions import VoiceCommandException
 from src.service import VoiceCommandService
 from src.enums import STTProvider
+from src.context import country_code_ctx, normalize_country_code
 
 router = APIRouter(prefix="/voice-command", tags=["Voice Command"])
 
@@ -19,6 +20,9 @@ async def websocket_endpoint(
     voice_command_service: VoiceCommandService = Depends(voice_command_service),
 ):
     session_id = None
+
+    raw_country_code = client_websocket.headers.get("X-Country-Code")
+    country_code_ctx.set(normalize_country_code(raw_country_code))
 
     await client_websocket.accept()
     

--- a/src/stt/client.py
+++ b/src/stt/client.py
@@ -18,6 +18,7 @@ import nest_pb2_grpc as nest_pb2_grpc
 from src.stt.exceptions import NaverClovaStreamingClientException, OpenAIStreamingClientException, VitoStreamingClientException, STTErrorCode
 
 from .config import vito_config, naver_clova_config, openai_config
+from src.context import country_code_ctx
 
 class STTClient(ABC):
     @abstractmethod
@@ -165,9 +166,12 @@ class NaverClovaStreamingClient(STTClient):
             
             call = stub.recognize(metadata=metadata) # type: ignore
             
+            country_code = country_code_ctx.get()
+            stt_language = "ko" if country_code == "KR" else "en"
+
             config_json = {
                 "transcription": {
-                    "language": self._config.language
+                    "language": stt_language
                 },
                 "semanticEpd": {
                     "skipEmptyText": self._config.skip_empty_text,  

--- a/src/user_session/recipe/client.py
+++ b/src/user_session/recipe/client.py
@@ -5,6 +5,7 @@ from .models import RecipeStep, RecipeIngredient
 from .schema import RecipeStepsResponse, RecipeIngredientsResponse
 from uuid import UUID
 from typing import List
+from src.context import country_code_ctx
 
 
 class RecipeClient(ABC):
@@ -21,14 +22,22 @@ class RecipeCheftoryClient(RecipeClient):
         self.api_base = recipe_config.api_base
 
     async def get_recipe_steps(self, recipe_id: UUID) -> List[RecipeStep]:
-        async with httpx.AsyncClient() as client:
+        headers = {
+            "X-Country-Code": country_code_ctx.get(),
+        }
+
+        async with httpx.AsyncClient(headers=headers) as client:
             response = await client.get(f"{self.api_base}/papi/v1/recipes/{recipe_id}/steps")
             response.raise_for_status()
             recipe_step_response = RecipeStepsResponse.model_validate(response.json())
             return [RecipeStep.from_response(step) for step in recipe_step_response.steps]
 
     async def get_recipe_ingredients(self, recipe_id: UUID) -> List[RecipeIngredient]:
-        async with httpx.AsyncClient() as client:
+        headers = {
+            "X-Country-Code": country_code_ctx.get(),
+        }
+
+        async with httpx.AsyncClient(headers=headers) as client:
             response = await client.get(f"{self.api_base}/papi/v1/recipes/{recipe_id}/ingredients")
             response.raise_for_status()
             recipe_ingredient_response = RecipeIngredientsResponse.model_validate(response.json())


### PR DESCRIPTION
# What

요청 단위로 country code를 ContextVar로 저장/전파하는 메커니즘을 추가했습니다. 이를 통해 앱 전반(비동기 포함)에서 동일한 국가 컨텍스트를 사용하고, 내부 서비스 호출 시에도 국가 정보를 일관되게 전달합니다.

# Why
	•	국가별 로직(STT 언어 선택, 응답/정책 분기 등)을 요청 흐름 전체에서 일관되게 적용하기 위함
	•	내부 API 호출(voice-command, recipe 등)에서 country code 누락으로 인해 행동이 달라지거나 오류가 발생하는 문제를 예방

# Changes
	•	Country Code Context
	•	country_code_ctx ContextVar 추가: 요청 스코프에서 country code를 저장/조회
	•	Normalization
	•	normalize_country_code 유틸 추가: 입력 값 표준화 (KR만 한국, 그 외 기본 US)
	•	STT Language 선택
	•	STT 클라이언트가 country_code_ctx 기반으로 언어를 동적으로 선택
	•	KR → Korean
	•	그 외 → English
	•	Internal API 호출 시 전파
	•	voice-command / recipe 관련 HTTP 요청에 X-Country-Code 헤더 자동 포함

# Behavior
	•	동일 요청 내 비동기 작업/서브서비스 호출에서도 country code가 유지되어, 국가별 정책이 안정적으로 적용됩니다.
	•	내부 API는 X-Country-Code 기반으로 국가별 처리(예: 언어/콘텐츠/정책)를 수행할 수 있습니다.